### PR TITLE
Add one-page options trading dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# ThetaTime
+# ThetaTime Dashboard
+
+A simple single-page web app for tracking closed options trades. Add trades manually or import from a CSV file and view summary statistics and charts.
+
+## Usage
+
+Open `index.html` in a browser. No build step or dependencies are required.
+
+## Features
+
+- Manual form entry or CSV import of closed trades
+- Automatic net profit calculation per trade
+- Scrollable, sortable trade table with profit/loss colors
+- Summary cards for total profit, average premium, trade count, average duration, win rate
+- Line chart of cumulative profit
+- Bar chart of monthly P&L
+
+All styling and behavior are implemented with plain CSS and JavaScript (no external libraries required).

--- a/app.js
+++ b/app.js
@@ -1,0 +1,166 @@
+const trades = [];
+const form = document.getElementById('trade-form');
+const tableBody = document.querySelector('#trade-table tbody');
+const summaryEl = document.getElementById('summary');
+const monthlySummaryEl = document.getElementById('monthly-summary');
+const csvInput = document.getElementById('csvFile');
+const lineCanvas = document.getElementById('profit-line');
+const barCanvas = document.getElementById('monthly-bar');
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const trade = {
+    ticker: document.getElementById('ticker').value,
+    strategy: document.getElementById('strategy').value,
+    openDate: document.getElementById('openDate').value,
+    closeDate: document.getElementById('closeDate').value,
+    strike: parseFloat(document.getElementById('strike').value),
+    premium: parseFloat(document.getElementById('premium').value),
+    buyback: parseFloat(document.getElementById('buyback').value) || 0,
+    qty: parseInt(document.getElementById('quantity').value) || 1,
+    commissions: parseFloat(document.getElementById('commissions').value) || 0
+  };
+  addTrade(trade);
+  form.reset();
+});
+
+csvInput.addEventListener('change', () => {
+  const file = csvInput.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => parseCSV(e.target.result);
+  reader.readAsText(file);
+  csvInput.value = '';
+});
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  for (let line of lines.slice(1)) {
+    const [ticker, strategy, openDate, closeDate, strike, premium, buyback, qty, commissions] = line.split(',');
+    addTrade({
+      ticker, strategy, openDate, closeDate,
+      strike: parseFloat(strike),
+      premium: parseFloat(premium),
+      buyback: parseFloat(buyback) || 0,
+      qty: parseInt(qty) || 1,
+      commissions: parseFloat(commissions) || 0
+    });
+  }
+}
+
+function addTrade(t) {
+  t.net = (t.premium - (t.buyback || 0) - (t.commissions || 0)) * (t.qty || 1);
+  trades.push(t);
+  updateTable();
+  updateSummary();
+  drawCharts();
+}
+
+function updateTable() {
+  tableBody.innerHTML = '';
+  trades.sort((a,b) => new Date(a.closeDate) - new Date(b.closeDate));
+  for (const t of trades) {
+    const tr = document.createElement('tr');
+    tr.className = t.net >= 0 ? 'profit' : 'loss';
+    tr.innerHTML = `
+      <td>${t.ticker}</td>
+      <td>${t.strategy}</td>
+      <td>${t.openDate}</td>
+      <td>${t.closeDate}</td>
+      <td>${t.strike.toFixed(2)}</td>
+      <td>${t.premium.toFixed(2)}</td>
+      <td>${t.buyback.toFixed(2)}</td>
+      <td>${t.qty}</td>
+      <td>${t.commissions.toFixed(2)}</td>
+      <td>${t.net.toFixed(2)}</td>
+    `;
+    tableBody.appendChild(tr);
+  }
+}
+
+function updateSummary() {
+  if (!trades.length) {
+    summaryEl.innerHTML = '';
+    monthlySummaryEl.innerHTML = '';
+    return;
+  }
+  const totalProfit = trades.reduce((s,t) => s + t.net, 0);
+  const avgPremium = trades.reduce((s,t) => s + t.premium, 0) / trades.length;
+  const durations = trades.map(t => (new Date(t.closeDate) - new Date(t.openDate))/86400000);
+  const avgDuration = durations.reduce((a,b)=>a+b,0)/durations.length;
+  const wins = trades.filter(t => t.net > 0).length;
+  const winRate = wins / trades.length * 100;
+  const cards = [
+    {label:'Total Profit', value: totalProfit.toFixed(2)},
+    {label:'Avg Premium', value: avgPremium.toFixed(2)},
+    {label:'Trades', value: trades.length},
+    {label:'Avg Duration', value: avgDuration.toFixed(1) + 'd'},
+    {label:'Win Rate', value: winRate.toFixed(1) + '%'}
+  ];
+  summaryEl.innerHTML = cards.map(c => `<div class="summary-card"><h3>${c.label}</h3><p>${c.value}</p></div>`).join('');
+
+  const monthly = {};
+  for (const t of trades) {
+    const m = t.closeDate.slice(0,7); // YYYY-MM
+    monthly[m] = (monthly[m] || 0) + t.net;
+  }
+  const rows = Object.entries(monthly).sort().map(([m,v])=>`<div>${m}: ${v.toFixed(2)}</div>`).join('');
+  monthlySummaryEl.innerHTML = rows;
+}
+
+function drawCharts() {
+  drawLineChart();
+  drawBarChart();
+}
+
+function drawLineChart() {
+  const ctx = lineCanvas.getContext('2d');
+  ctx.clearRect(0,0,lineCanvas.width,lineCanvas.height);
+  if(!trades.length) return;
+  const points = [];
+  let cum = 0;
+  for (const t of trades) {
+    cum += t.net;
+    points.push({date:new Date(t.closeDate), value:cum});
+  }
+  const minDate = points[0].date;
+  const maxDate = points[points.length-1].date;
+  const minY = Math.min(0, ...points.map(p=>p.value));
+  const maxY = Math.max(...points.map(p=>p.value));
+  const pad = 40;
+  const w = lineCanvas.width - pad*2;
+  const h = lineCanvas.height - pad*2;
+  ctx.strokeStyle = '#fff';
+  ctx.beginPath();
+  points.forEach((p,i)=>{
+    const x = pad + (p.date-minDate)/(maxDate-minDate)*w;
+    const y = pad + h - (p.value-minY)/(maxY-minY)*h;
+    if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+  });
+  ctx.stroke();
+}
+
+function drawBarChart() {
+  const ctx = barCanvas.getContext('2d');
+  ctx.clearRect(0,0,barCanvas.width,barCanvas.height);
+  if(!trades.length) return;
+  const monthly = {};
+  for(const t of trades){
+    const m = t.closeDate.slice(0,7);
+    monthly[m] = (monthly[m]||0)+t.net;
+  }
+  const entries = Object.entries(monthly).sort();
+  const pad = 40;
+  const w = barCanvas.width - pad*2;
+  const h = barCanvas.height - pad*2;
+  const maxVal = Math.max(...entries.map(e=>e[1]), 0);
+  const barWidth = w/entries.length*0.6;
+  entries.forEach(([m,v],i)=>{
+    const x = pad + i*(w/entries.length) + barWidth*0.2;
+    const y = pad + h - (v/maxVal)*h;
+    ctx.fillStyle = v>=0? 'rgba(16,185,129,0.7)' : 'rgba(239,68,68,0.7)';
+    ctx.fillRect(x,y,barWidth,(v/maxVal)*h);
+    ctx.fillStyle = '#fff';
+    ctx.fillText(m, x, h + pad + 10);
+  });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ThetaTime Dashboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>ThetaTime Options Tracker</h1>
+    </header>
+
+    <section id="summary" class="summary-cards"></section>
+
+    <section class="input-section">
+      <h2>Add Trade</h2>
+      <form id="trade-form">
+        <div class="form-grid">
+          <input type="text" id="ticker" placeholder="Ticker" required>
+          <input type="text" id="strategy" placeholder="Strategy" required>
+          <input type="date" id="openDate" required>
+          <input type="date" id="closeDate" required>
+          <input type="number" step="0.01" id="strike" placeholder="Strike" required>
+          <input type="number" step="0.01" id="premium" placeholder="Premium" required>
+          <input type="number" step="0.01" id="buyback" placeholder="Buyback" value="0">
+          <input type="number" step="1" id="quantity" placeholder="Qty" value="1">
+          <input type="number" step="0.01" id="commissions" placeholder="Commissions" value="0">
+        </div>
+        <button type="submit">Add Trade</button>
+      </form>
+      <div class="csv-input">
+        <label>Import CSV
+          <input type="file" id="csvFile" accept=".csv">
+        </label>
+      </div>
+    </section>
+
+    <section class="table-section">
+      <h2>Trades</h2>
+      <div class="table-container">
+        <table id="trade-table">
+          <thead>
+            <tr>
+              <th>Ticker</th>
+              <th>Strategy</th>
+              <th>Open</th>
+              <th>Close</th>
+              <th>Strike</th>
+              <th>Premium</th>
+              <th>Buyback</th>
+              <th>Qty</th>
+              <th>Commissions</th>
+              <th>Net</th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="graphs">
+      <h2>Performance</h2>
+      <canvas id="profit-line" width="600" height="300"></canvas>
+      <canvas id="monthly-bar" width="600" height="300"></canvas>
+    </section>
+
+    <footer id="monthly-summary"></footer>
+  </div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,90 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  color: #fff;
+}
+.container {
+  max-width: 1200px;
+  margin: auto;
+  padding: 1rem;
+}
+header h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-size: 2rem;
+}
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.summary-card {
+  background: rgba(255,255,255,0.1);
+  backdrop-filter: blur(6px);
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+}
+.input-section {
+  background: rgba(255,255,255,0.1);
+  backdrop-filter: blur(6px);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px,1fr));
+  gap: 0.5rem;
+}
+button {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #3b82f6;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+button:hover { background: #2563eb; }
+.csv-input { margin-top: 1rem; }
+.table-container {
+  max-height: 300px;
+  overflow-y: auto;
+}
+#trade-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+#trade-table th {
+  position: sticky;
+  top: 0;
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(4px);
+}
+#trade-table th, #trade-table td {
+  padding: 0.5rem;
+  text-align: right;
+}
+#trade-table td:first-child, #trade-table th:first-child {
+  text-align: left;
+}
+tr.profit { background: rgba(16,185,129,0.2); }
+tr.loss { background: rgba(239,68,68,0.2); }
+.graphs {
+  background: rgba(255,255,255,0.1);
+  backdrop-filter: blur(6px);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-top: 1rem;
+}
+footer {
+  margin-top: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- create single-page dashboard to track options trades
- display summary cards, trade table, line & bar charts
- allow manual and CSV trade entry

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6889427ed850832a92b28af590d17bd7