### PR TITLE
Modernize UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Open `index.html` in a browser. No build step or dependencies are required.
 - Line chart of cumulative profit
 - Bar chart of monthly P&L
 
-All styling and behavior are implemented with plain CSS and JavaScript (no external libraries required).
+All styling and behavior are implemented with plain CSS and JavaScript (no external libraries required). The default theme takes inspiration from the Robinhood trading platform.

--- a/app.js
+++ b/app.js
@@ -130,7 +130,7 @@ function drawLineChart() {
   const pad = 40;
   const w = lineCanvas.width - pad*2;
   const h = lineCanvas.height - pad*2;
-  ctx.strokeStyle = '#fff';
+  ctx.strokeStyle = '#00c853';
   ctx.beginPath();
   points.forEach((p,i)=>{
     const x = pad + (p.date-minDate)/(maxDate-minDate)*w;
@@ -158,7 +158,7 @@ function drawBarChart() {
   entries.forEach(([m,v],i)=>{
     const x = pad + i*(w/entries.length) + barWidth*0.2;
     const y = pad + h - (v/maxVal)*h;
-    ctx.fillStyle = v>=0? 'rgba(16,185,129,0.7)' : 'rgba(239,68,68,0.7)';
+    ctx.fillStyle = v>=0? 'rgba(0,200,83,0.7)' : 'rgba(239,68,68,0.7)';
     ctx.fillRect(x,y,barWidth,(v/maxVal)*h);
     ctx.fillStyle = '#fff';
     ctx.fillText(m, x, h + pad + 10);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ThetaTime Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -3,9 +3,9 @@
 }
 body {
   margin: 0;
-  font-family: sans-serif;
-  background: linear-gradient(135deg, #1e3c72, #2a5298);
-  color: #fff;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(135deg, #0f1115, #13171c);
+  color: #f0f6f0;
 }
 .container {
   max-width: 1200px;
@@ -16,6 +16,7 @@ header h1 {
   text-align: center;
   margin-bottom: 1rem;
   font-size: 2rem;
+  color: #00c853;
 }
 .summary-cards {
   display: grid;
@@ -24,14 +25,14 @@ header h1 {
   margin-bottom: 1rem;
 }
 .summary-card {
-  background: rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
   backdrop-filter: blur(6px);
   padding: 1rem;
   border-radius: 8px;
   text-align: center;
 }
 .input-section {
-  background: rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
   backdrop-filter: blur(6px);
   padding: 1rem;
   border-radius: 8px;
@@ -47,12 +48,12 @@ button {
   padding: 0.5rem 1rem;
   border: none;
   border-radius: 4px;
-  background: #3b82f6;
+  background: #00c853;
   color: #fff;
   cursor: pointer;
   transition: background 0.3s;
 }
-button:hover { background: #2563eb; }
+button:hover { background: #02b14f; }
 .csv-input { margin-top: 1rem; }
 .table-container {
   max-height: 300px;
@@ -65,7 +66,7 @@ button:hover { background: #2563eb; }
 #trade-table th {
   position: sticky;
   top: 0;
-  background: rgba(0,0,0,0.6);
+  background: rgba(255,255,255,0.05);
   backdrop-filter: blur(4px);
 }
 #trade-table th, #trade-table td {
@@ -75,10 +76,10 @@ button:hover { background: #2563eb; }
 #trade-table td:first-child, #trade-table th:first-child {
   text-align: left;
 }
-tr.profit { background: rgba(16,185,129,0.2); }
-tr.loss { background: rgba(239,68,68,0.2); }
+tr.profit { background: rgba(0,200,83,0.15); }
+tr.loss { background: rgba(239,68,68,0.15); }
 .graphs {
-  background: rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
   backdrop-filter: blur(6px);
   padding: 1rem;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- add Inter font from Google fonts
- modernize dark theme colors in CSS
- use accent green for headers, buttons, charts and table highlights
- mention Robinhood-inspired theme in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688947643598832aadd11448c1848598