### PR TITLE
Add default trade values on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,37 @@ const csvInput = document.getElementById('csvFile');
 const lineCanvas = document.getElementById('profit-line');
 const barCanvas = document.getElementById('monthly-bar');
 
+// Set preset default values for the trade form inputs
+function setDefaultFormValues() {
+  document.getElementById('ticker').value = 'GME';
+  document.getElementById('strategy').value = 'Covered Call';
+
+  const formatDate = d => d.toISOString().slice(0, 10);
+
+  const today = new Date();
+  const day = today.getDay();
+
+  const mondayThisWeek = new Date(today);
+  mondayThisWeek.setDate(today.getDate() - ((day + 6) % 7));
+
+  const lastMonday = new Date(mondayThisWeek);
+  lastMonday.setDate(mondayThisWeek.getDate() - 7);
+
+  const lastFriday = new Date(lastMonday);
+  lastFriday.setDate(lastMonday.getDate() + 4);
+
+  document.getElementById('openDate').value = formatDate(lastMonday);
+  document.getElementById('closeDate').value = formatDate(lastFriday);
+
+  document.getElementById('strike').value = 25;
+  document.getElementById('premium').value = 0.10;
+  document.getElementById('buyback').value = 0.1;
+  document.getElementById('quantity').value = 10;
+  document.getElementById('commissions').value = 10;
+}
+
+setDefaultFormValues();
+
 form.addEventListener('submit', e => {
   e.preventDefault();
   const trade = {


### PR DESCRIPTION
## Summary
- preset trade form fields on page load with typical example values

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68894a03fe30832aacdbcdc7609763c0