### PR TITLE
Fix profit formula for option trades

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,8 @@ function parseCSV(text) {
 
 function addTrade(t) {
   t.id = Date.now() + Math.random();
-  t.net = (t.premium - (t.buyback || 0) - (t.commissions || 0)) * (t.qty || 1);
+  const perContract = (t.premium - (t.buyback || 0)) * 100 - (t.commissions || 0);
+  t.net = perContract * (t.qty || 1);
   trades.push(t);
   updateTable();
   updateSummary();
@@ -99,12 +100,12 @@ function updateTable() {
       <td>${t.strategy}</td>
       <td>${t.openDate}</td>
       <td>${t.closeDate}</td>
-      <td>${t.strike.toFixed(2)}</td>
+      <td>$${t.strike.toFixed(2)}</td>
       <td>${t.premium.toFixed(2)}</td>
       <td>${t.buyback.toFixed(2)}</td>
       <td>${t.qty}</td>
-      <td>${t.commissions.toFixed(2)}</td>
-      <td>${t.net.toFixed(2)}</td>
+      <td>$${t.commissions.toFixed(2)}</td>
+      <td>$${t.net.toFixed(2)}</td>
       <td><button class="delete-btn" data-id="${t.id}" title="Delete">&times;</button></td>
     `;
     tr.querySelector('.delete-btn').addEventListener('click', () => deleteTrade(t.id));
@@ -135,7 +136,7 @@ function updateSummary() {
   const wins = trades.filter(t => t.net > 0).length;
   const winRate = wins / trades.length * 100;
   const cards = [
-    {label:'Total Profit', value: totalProfit.toFixed(2)},
+    {label:'Total Profit', value: '$' + totalProfit.toFixed(2)},
     {label:'Avg Premium', value: avgPremium.toFixed(2)},
     {label:'Trades', value: trades.length},
     {label:'Avg Duration', value: avgDuration.toFixed(1) + 'd'},
@@ -148,7 +149,7 @@ function updateSummary() {
     const m = t.closeDate.slice(0,7); // YYYY-MM
     monthly[m] = (monthly[m] || 0) + t.net;
   }
-  const rows = Object.entries(monthly).sort().map(([m,v])=>`<div>${m}: ${v.toFixed(2)}</div>`).join('');
+  const rows = Object.entries(monthly).sort().map(([m,v])=>`<div>${m}: $${v.toFixed(2)}</div>`).join('');
   monthlySummaryEl.innerHTML = rows;
 }
 

--- a/index.html
+++ b/index.html
@@ -25,11 +25,11 @@
           <input type="text" id="strategy" placeholder="Strategy" required>
           <input type="date" id="openDate" required>
           <input type="date" id="closeDate" required>
-          <input type="number" step="0.01" id="strike" placeholder="Strike" required>
+          <input type="number" step="0.01" id="strike" placeholder="Strike ($)" required>
           <input type="number" step="0.01" id="premium" placeholder="Premium" required>
           <input type="number" step="0.01" id="buyback" placeholder="Buyback" value="0">
           <input type="number" step="1" id="quantity" placeholder="Qty" value="1">
-          <input type="number" step="0.01" id="commissions" placeholder="Commissions" value="0">
+          <input type="number" step="0.01" id="commissions" placeholder="Fees ($)" value="0">
         </div>
         <button type="submit">Add Trade</button>
       </form>
@@ -50,11 +50,11 @@
               <th>Strategy</th>
               <th>Open</th>
               <th>Close</th>
-              <th>Strike</th>
+              <th>Strike ($)</th>
               <th>Premium</th>
               <th>Buyback</th>
               <th>Qty</th>
-              <th>Commissions</th>
+              <th>Fees ($)</th>
               <th>Net</th>
               <th></th>
             </tr>


### PR DESCRIPTION
## Summary
- treat each contract as 100 shares when calculating net profit
- show strike, fees and profit as dollar values
- tweak headings and placeholders to reflect dollar amounts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68894bd6c484832aa2d7e15c337f7d2c