### PR TITLE
Add preset trade form values

### DIFF
--- a/app.js
+++ b/app.js
@@ -207,9 +207,15 @@ function loadTrades() {
 }
 
 function setDefaultFormValues() {
+  const {monday, friday} = getLastWeekDates();
+  document.getElementById('ticker').value = 'GME';
+  document.getElementById('openDate').value = formatDate(monday);
+  document.getElementById('closeDate').value = formatDate(friday);
+  document.getElementById('strike').value = '25';
+  document.getElementById('premium').value = '0.10';
   document.getElementById('buyback').value = '0.01';
-  document.getElementById('quantity').value = '1';
-  document.getElementById('commissions').value = '0';
+  document.getElementById('quantity').value = '10';
+  document.getElementById('commissions').value = '10';
 }
 
 function ensurePresetTrade() {

--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@
       <h2>Add Trade</h2>
       <form id="trade-form">
         <div class="form-grid">
-          <input type="text" id="ticker" placeholder="Ticker" required>
+          <input type="text" id="ticker" placeholder="Ticker" value="GME" required>
           <input type="date" id="openDate" required>
           <input type="date" id="closeDate" required>
-          <input type="number" step="0.01" id="strike" placeholder="Strike ($)" required>
-          <input type="number" step="0.01" id="premium" placeholder="Premium" required>
+          <input type="number" step="0.01" id="strike" placeholder="Strike ($)" value="25" required>
+          <input type="number" step="0.01" id="premium" placeholder="Premium" value="0.10" required>
           <input type="number" step="0.01" id="buyback" placeholder="Buyback" value="0.01">
-          <input type="number" step="1" id="quantity" placeholder="Qty" value="1">
-          <input type="number" step="0.01" id="commissions" placeholder="Fees ($)" value="0">
+          <input type="number" step="1" id="quantity" placeholder="Qty" value="10">
+          <input type="number" step="0.01" id="commissions" placeholder="Fees ($)" value="10">
         </div>
         <button type="submit">Add Trade</button>
       </form>


### PR DESCRIPTION
## Summary
- pre-fill trade form values to simplify adding trades
- default ticker is GME

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688954c5af18832a8ae1354f2f5d0376