### PR TITLE
Update profit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open `index.html` in a browser. No build step or dependencies are required.
 - Manual form entry of closed trades
 - Automatic net profit calculation per trade
 - Scrollable, sortable trade table with profit/loss colors
-- Summary cards for total profit, average premium, trade count, average duration, win rate
+- Summary cards for total profit and cumulative profit percentage
 - Line chart of cumulative profit
 - Bar chart of monthly P&L
 - Interactive charts powered by Chart.js

--- a/app.js
+++ b/app.js
@@ -85,18 +85,13 @@ function updateSummary() {
     monthlySummaryEl.innerHTML = '';
     return;
   }
-  const totalProfit = trades.reduce((s,t) => s + t.net, 0);
-  const avgPremium = trades.reduce((s,t) => s + t.premium, 0) / trades.length;
-  const durations = trades.map(t => (new Date(t.closeDate) - new Date(t.openDate))/86400000);
-  const avgDuration = durations.reduce((a,b)=>a+b,0)/durations.length;
-  const wins = trades.filter(t => t.net > 0).length;
-  const winRate = wins / trades.length * 100;
+  const totalProfit = trades.reduce((s, t) => s + t.net, 0);
+  const totalCapital = trades.reduce((s, t) => s + (t.strike * 100 * t.qty), 0);
+  const winRate = totalCapital ? (totalProfit / totalCapital) * 100 : 0;
+
   const cards = [
-    {label:'Total Profit', value: '$' + totalProfit.toFixed(2)},
-    {label:'Avg Premium', value: avgPremium.toFixed(2)},
-    {label:'Trades', value: trades.length},
-    {label:'Avg Duration', value: avgDuration.toFixed(1) + 'd'},
-    {label:'Win Rate', value: winRate.toFixed(1) + '%'}
+    { label: 'Total Profit', value: '$' + totalProfit.toFixed(2) },
+    { label: 'Win Rate', value: winRate.toFixed(1) + '%' }
   ];
   summaryEl.innerHTML = cards.map(c => `<div class="summary-card"><h3>${c.label}</h3><p>${c.value}</p></div>`).join('');
 


### PR DESCRIPTION
## Summary
- simplify summary metrics and remove avg premium, trade count and duration
- compute win rate as cumulative profit relative to trade capital

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68895b5504e4832a8bc0d166eb97a7e7