### PR TITLE
Simplify trade entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,6 @@ form.addEventListener('submit', e => {
   e.preventDefault();
   const trade = {
     ticker: document.getElementById('ticker').value,
-    openDate: document.getElementById('openDate').value,
     closeDate: document.getElementById('closeDate').value,
     strike: parseFloat(document.getElementById('strike').value),
     premium: parseFloat(document.getElementById('premium').value),
@@ -73,7 +72,6 @@ function updateTable() {
     if (isEditing) {
       tr.innerHTML = `
         <td contenteditable data-field="ticker">${t.ticker}</td>
-        <td contenteditable data-field="openDate">${t.openDate}</td>
         <td contenteditable data-field="closeDate">${t.closeDate}</td>
         <td contenteditable data-field="strike">${t.strike.toFixed(2)}</td>
         <td contenteditable data-field="premium">${t.premium.toFixed(2)}</td>
@@ -87,7 +85,6 @@ function updateTable() {
     } else {
       tr.innerHTML = `
         <td>${t.ticker}</td>
-        <td>${t.openDate}</td>
         <td>${t.closeDate}</td>
         <td>$${t.strike.toFixed(2)}</td>
         <td>${t.premium.toFixed(2)}</td>
@@ -263,10 +260,8 @@ function loadTrades() {
 }
 
 function setDefaultFormValues() {
-  const {monday, friday} = getLastWeekDates();
   document.getElementById('ticker').value = 'GME';
-  document.getElementById('openDate').value = formatDate(monday);
-  document.getElementById('closeDate').value = formatDate(friday);
+  document.getElementById('closeDate').value = formatDate(new Date());
   document.getElementById('strike').value = '25';
   document.getElementById('premium').value = '0.10';
   document.getElementById('buyback').value = '0.01';
@@ -276,29 +271,16 @@ function setDefaultFormValues() {
 
 function ensurePresetTrade() {
   if (trades.length) return;
-  const {monday, friday} = getLastWeekDates();
+  const today = new Date();
   addTrade({
     ticker: 'GME',
-    openDate: formatDate(monday),
-    closeDate: formatDate(friday),
+    closeDate: formatDate(today),
     strike: 25,
     premium: 0.1,
     buyback: 0.01,
     qty: 10,
     commissions: 10
   });
-}
-
-function getLastWeekDates() {
-  const today = new Date();
-  const day = today.getDay();
-  const mondayThisWeek = new Date(today);
-  mondayThisWeek.setDate(today.getDate() - ((day + 6) % 7));
-  const mondayLastWeek = new Date(mondayThisWeek);
-  mondayLastWeek.setDate(mondayThisWeek.getDate() - 7);
-  const fridayLastWeek = new Date(mondayLastWeek);
-  fridayLastWeek.setDate(mondayLastWeek.getDate() + 4);
-  return {monday: mondayLastWeek, friday: fridayLastWeek};
 }
 
 function formatDate(d) {

--- a/index.html
+++ b/index.html
@@ -22,14 +22,34 @@
       <h2>Add Trade</h2>
       <form id="trade-form">
         <div class="form-grid">
-          <input type="text" id="ticker" placeholder="Ticker" value="GME" required>
-          <input type="date" id="openDate" required>
-          <input type="date" id="closeDate" required>
-          <input type="number" step="0.01" id="strike" placeholder="Strike ($)" value="25" required>
-          <input type="number" step="0.01" id="premium" placeholder="Premium" value="0.10" required>
-          <input type="number" step="0.01" id="buyback" placeholder="Buyback" value="0.01">
-          <input type="number" step="1" id="quantity" placeholder="Qty" value="10">
-          <input type="number" step="0.01" id="commissions" placeholder="Fees ($)" value="10">
+          <div class="form-field">
+            <label for="ticker">Ticker</label>
+            <input type="text" id="ticker" placeholder="Ticker" value="GME" required>
+          </div>
+          <div class="form-field">
+            <label for="closeDate">Close Date</label>
+            <input type="date" id="closeDate" required>
+          </div>
+          <div class="form-field">
+            <label for="strike">Strike ($)</label>
+            <input type="number" step="0.01" id="strike" placeholder="Strike ($)" value="25" required>
+          </div>
+          <div class="form-field">
+            <label for="premium">Premium</label>
+            <input type="number" step="0.01" id="premium" placeholder="Premium" value="0.10" required>
+          </div>
+          <div class="form-field">
+            <label for="buyback">Buyback</label>
+            <input type="number" step="0.01" id="buyback" placeholder="Buyback" value="0.01">
+          </div>
+          <div class="form-field">
+            <label for="quantity">Qty</label>
+            <input type="number" step="1" id="quantity" placeholder="Qty" value="10">
+          </div>
+          <div class="form-field">
+            <label for="commissions">Fees ($)</label>
+            <input type="number" step="0.01" id="commissions" placeholder="Fees ($)" value="10">
+          </div>
         </div>
         <button type="submit">Add Trade</button>
       </form>
@@ -45,7 +65,6 @@
           <thead>
             <tr>
               <th>Ticker</th>
-              <th>Open</th>
               <th>Close</th>
               <th>Strike ($)</th>
               <th>Premium</th>

--- a/style.css
+++ b/style.css
@@ -68,6 +68,16 @@ header h1 {
   gap: 0.5rem;
 }
 
+.form-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-field label {
+  font-size: 0.75rem;
+  margin-bottom: 0.2rem;
+}
+
 input[type="text"],
 input[type="number"],
 input[type="date"],


### PR DESCRIPTION
## Summary
- drop Open column and open date field
- add labels above inputs and small form-field styling
- default close date/preset trade uses today

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68895d81a988832a9586ed99d23ffd32