### PR TITLE
Add profit percentage column to trades table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Open `index.html` in a browser. No build step or dependencies are required.
 
 - Manual form entry of closed trades
 - Automatic net profit calculation per trade
-- Scrollable, sortable trade table with profit/loss colors
+- Scrollable, sortable trade table with profit/loss colors and per-trade % return
 - Summary cards for total profit and cumulative profit percentage
 - Line chart of cumulative profit
 - Bar chart of monthly P&L

--- a/app.js
+++ b/app.js
@@ -55,6 +55,8 @@ function addTrade(t) {
   t.commissions = t.commissions || 0;
   const gross = (t.premium - (t.buyback || 0)) * 100 * t.qty;
   t.net = gross - t.commissions;
+  const capital = t.strike * 100 * t.qty;
+  t.percent = capital ? (t.net / capital) * 100 : 0;
   trades.push(t);
   saveTrades();
   updateTable();
@@ -78,7 +80,8 @@ function updateTable() {
         <td contenteditable data-field="buyback">${t.buyback.toFixed(2)}</td>
         <td contenteditable data-field="qty">${t.qty}</td>
         <td contenteditable data-field="commissions">${t.commissions.toFixed(2)}</td>
-        <td>$${t.net.toFixed(2)}</td>
+        <td class="net">$${t.net.toFixed(2)}</td>
+        <td>${t.percent.toFixed(1)}%</td>
         <td><button class="delete-btn" data-id="${t.id}" title="Delete">&times;</button></td>
       `;
       tr.querySelector('.delete-btn').addEventListener('click', () => deleteTrade(t.id));
@@ -91,7 +94,8 @@ function updateTable() {
         <td>${t.buyback.toFixed(2)}</td>
         <td>${t.qty}</td>
         <td>$${t.commissions.toFixed(2)}</td>
-        <td>$${t.net.toFixed(2)}</td>
+        <td class="net">$${t.net.toFixed(2)}</td>
+        <td>${t.percent.toFixed(1)}%</td>
         <td></td>
       `;
     }
@@ -128,6 +132,8 @@ function saveEdits() {
     });
     const gross = (trade.premium - (trade.buyback || 0)) * 100 * trade.qty;
     trade.net = gross - trade.commissions;
+    const cap = trade.strike * 100 * trade.qty;
+    trade.percent = cap ? (trade.net / cap) * 100 : 0;
   });
   saveTrades();
 }
@@ -251,6 +257,8 @@ function loadTrades() {
         t.commissions = parseFloat(t.commissions) || 0;
         const gross = (t.premium - (t.buyback || 0)) * 100 * t.qty;
         t.net = gross - t.commissions;
+        const cap = t.strike * 100 * t.qty;
+        t.percent = cap ? (t.net / cap) * 100 : 0;
         trades.push(t);
       });
     }

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
               <th>Qty</th>
               <th>Fees ($)</th>
               <th>Net</th>
+              <th>%</th>
               <th></th>
             </tr>
           </thead>

--- a/style.css
+++ b/style.css
@@ -170,16 +170,15 @@ canvas {
   background: rgba(239, 68, 68, 0.1);
 }
 
-#trade-table tr.profit td:last-child,
-#trade-table tr.loss td:last-child {
+#trade-table td.net {
   font-weight: 600;
 }
 
-#trade-table tr.profit td:last-child {
+#trade-table tr.profit td.net {
   color: var(--accent);
 }
 
-#trade-table tr.loss td:last-child {
+#trade-table tr.loss td.net {
   color: #ef4444;
 }
 footer {


### PR DESCRIPTION
## Summary
- calculate per-trade percent return in app logic
- display percent column in trades table
- style net profit cell with new `.net` class
- mention percent column in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889606066e4832ab540dff727c7a189