### PR TITLE
Replace win rate with cumulative percent profit

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,12 +145,11 @@ function updateSummary() {
     return;
   }
   const totalProfit = trades.reduce((s, t) => s + t.net, 0);
-  const wins = trades.filter(t => t.net > 0).length;
-  const winRate = trades.length ? (wins / trades.length) * 100 : 0;
+  const cumulativePercent = trades.reduce((s, t) => s + t.percent, 0);
 
   const cards = [
     { label: 'Total Profit', value: '$' + totalProfit.toFixed(2) },
-    { label: 'Win Rate', value: winRate.toFixed(1) + '%' }
+    { label: 'Cumulative % Profit', value: cumulativePercent.toFixed(2) + '%' }
   ];
   summaryEl.innerHTML = cards.map(c => `<div class="summary-card"><h3>${c.label}</h3><p>${c.value}</p></div>`).join('');
 


### PR DESCRIPTION
## Summary
- compute cumulative percent profit instead of win rate
- rename the summary card label accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688965322cb4832abafed0d07e79fc4c